### PR TITLE
Fix MAGP006 and MAGP007 HTML comments

### DIFF
--- a/_posts/2024-02-15-006.md
+++ b/_posts/2024-02-15-006.md
@@ -45,7 +45,9 @@ Episode Six -- Introductions.
 
 ------
 
-<!-- 1. INT. OIAR OFFICE -- NIGHT, CLEAR (COMPUTER) SAM is typing away on his computer, though the rhythm of it is unsteady. He is exhausted and keeps almost drifting off to sleep before jolting himself back awake. From her desk, ALICE starts to whistle a lullaby at him.  -->
+##### [INT. OIAR OFFICE -- NIGHT, CLEAR (COMPUTER)]
+
+##### [SAM is typing away on his computer, though the rhythm of it is unsteady. He is exhausted and keeps almost drifting off to sleep before jolting himself back awake. From her desk, ALICE starts to whistle a lullaby at him.]
 
 ##### [The microphone of the decrepit OIAR computer once again turns on]
 
@@ -213,7 +215,11 @@ Which they won't. _(she sits)_ Now, like I said, massively behind.
 
 ##### [There is a ringing as a phone call is made, then tinny phone audio:]
 
-<!-- They resume typing in silence, until the computer starts to play a casefile. 2. CYBER -- N/A, N/A (999 CALL) There is a ringing as a call comes through.  -->
+##### [They resume typing in silence, until the computer starts to play a casefile.]
+
+##### [CYBER -- N/A, N/A (999 CALL)]
+
+##### [There is a ringing as a call comes through.]
 
 #### OPERATOR 1
 
@@ -463,7 +469,7 @@ I do hope we speak again soon, Mr. Operator. See if we can't find some other fri
 
 ##### [Sam lets out a noise of bemusement at the case]
 
-<!-- The others clearly weren't listening.  -->
+##### [The others clearly weren't listening.]
 
 #### SAM
 
@@ -551,9 +557,7 @@ She's getting a cup of coffee from the break room. Her name is Celia, and I trus
 
 We'll certainly try.
 
-##### [Footsteps as CELIA enters]
-
-<!-- with a cup of coffee and a little donut.  -->
+##### [Footsteps as CELIA enters with a cup of coffee and a little donut.]
 
 #### CELIA
 
@@ -737,7 +741,9 @@ Wouldn't dream of it.
 
 ------
 
-<!-- 4. OIAR BREAKROOM -- NIGHT, CLEAR (CCTV) Sam is making himself another cup of coffee. He sighs to himself waits for the coffee machine to finish dispensing. Alice enters with Celia as he picks up the mug.  -->
+##### [OIAR BREAKROOM -- NIGHT, CLEAR (CCTV)]
+
+##### [Sam is making himself another cup of coffee. He sighs to himself waits for the coffee machine to finish dispensing. Alice enters with Celia as he picks up the mug.]
 
 ##### [We are now listening through the echoey CCTV of the breakroom]
 

--- a/_posts/2024-02-22-007.md
+++ b/_posts/2024-02-22-007.md
@@ -45,9 +45,9 @@ Episode Seven -- Give and Take.
 
 ------
 
-<!-- 1. INT. O.I.A.R. OFFICE -- NIGHT, CLEAR (COMPUTER)
+##### [INT. O.I.A.R. OFFICE -- NIGHT, CLEAR (COMPUTER)]
 
-ALICE is sat at the computer giving CELIA an introduction to the Freddie system.  -->
+##### [ALICE is sat at the computer giving CELIA an introduction to the Freddie system.]
 
 ##### [The decrepit OIAR computer once again whirs on]
 
@@ -337,7 +337,9 @@ Doesn't matter. I'm sure it wasn't anyone important.
 
 ------
 
-<!-- 4. I.T. "OFFICE" -- NIGHT, CLEAR (SAM'S PHONE) SAM stands in the corridor and knocks on the metallic door to the IT office. There are the distinct sounds of someone typing on a keyboard in the room, it doesn't sound like it's going well.  -->
+##### [I.T. "OFFICE" -- NIGHT, CLEAR (SAM'S PHONE)]
+
+##### [SAM stands in the corridor and knocks on the metallic door to the IT office. There are the distinct sounds of someone typing on a keyboard in the room, it doesn't sound like it's going well.]
 
 ##### [Several beeps. The sound quality shifts to tinnier: we are in a phone recording]
 
@@ -477,9 +479,9 @@ It's already recorded too --
 
 ------
 
-<!-- #### 5. INT. MANAGER'S OFFICE -- NIGHT, WINDY (MANAGER'S LANDLINE) -->
+#### [INT. MANAGER'S OFFICE -- NIGHT, WINDY (MANAGER'S LANDLINE)]
 
-<!-- LENA is sat speaking on the phone, we do not hear the man on the other end of the line but it sounds like he is in a restaurant or similar environment.  -->
+#### [LENA is sat speaking on the phone, we do not hear the man on the other end of the line but it sounds like he is in a restaurant or similar environment.]
 
 ##### [Another recording: we are listening through the landline in an office]
 


### PR DESCRIPTION
They broke epub rendering:

<img width="1399" height="792" alt="image" src="https://github.com/user-attachments/assets/17fa4010-d720-4d15-96be-6780d7b97ef4" />

I did not find how epubs are generated though, is the generating script not in the repository?